### PR TITLE
56 penalty weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,14 @@ value for depth, even when this is not known accurately.
 
 The flow parameters are calculated by maximising the cross-correlation between the measured spectrum of the surface elevation and a synthetic spectrum generated according to linear wave theory. This is done using a differential evolution algorithm (`scipy.optimize.differential_evolution`) which maximises the chances to identify a global maximum but may converge slowly, especially when the window size is large and/or there are more parameters to be estimated (e.g., also the water depth).
 
-Setting `twosteps = True` (default is `True`) will run the optimisation in two steps. The first step employs a trimmed spectrum with reduced dimensions, and is used to identify an initial estimate of the flow velocity (depth effects are neglected during the first step, even when "depth" = 0). During the second step, the search of the optimum is confined within a region between 90% and 110% of the initial estimate. The two-steps approach can reduce the computation time by around 50% for large problems, but could be less robust if the input images are noisy or have a low resolution. In that case, it is recommended to run `twosteps = True` while setting `first_pass_downsample = 1` during the initialisation to avoid an eccessive loss in resolution.
+`twosteps = True` (default) will run the optimisation in two steps (set to `False` for single run). The first step
+employs a trimmed
+spectrum with reduced dimensions, and is used to identify an initial estimate of the flow velocity (depth effects are
+neglected during the first step, even when `depth==0`). During the second step, the search of the optimum is confined
+within a region between 90% and 110% of the initial estimate. The two-steps approach can reduce the computation time
+by around 50% for large problems, but could be less robust if the input images are noisy or have a low resolution. In
+that case, it is recommended to run `twosteps = True` while setting `first_pass_downsample = 1` during the
+initialisation to avoid an excessive loss in resolution.
 
 > [!IMPORTANT]
 > Optimization of the velocities occurs with a possibly large amount of spawned parallelized processes.

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ def main():
   iw.velocimetry(
     alpha=0.85,  # alpha represents the depth-averaged velocity over surface velocity [-]
     depth=0.3,  # depth in [m] has to be known or estimated. If depth = 0, then the depth is estimated.
-    twosteps=False # option to perform the calculation in two steps. If True, the first step is calculated based on
-                   # a reduced-dimension problem and serves as initialisation of the second step. 
+    twosteps=True # option to perform the calculation in two steps. If True, the first step is calculated based on
+                   # a reduced-dimension problem and serves as initialisation of the second step.
   )
   
   ax = plt.axes()
@@ -236,7 +236,7 @@ value for depth, even when this is not known accurately.
 
 The flow parameters are calculated by maximising the cross-correlation between the measured spectrum of the surface elevation and a synthetic spectrum generated according to linear wave theory. This is done using a differential evolution algorithm (`scipy.optimize.differential_evolution`) which maximises the chances to identify a global maximum but may converge slowly, especially when the window size is large and/or there are more parameters to be estimated (e.g., also the water depth).
 
-Setting `twosteps = True` (default is `False`) will run the optimisation in two steps. The first step employs a trimmed spectrum with reduced dimensions, and is used to identify an initial estimate of the flow velocity (depth effects are neglected during the first step, even when "depth" = 0). During the second step, the search of the optimum is confined within a region between 90% and 110% of the initial estimate. The two-steps approach can reduce the computation time by around 50% for large problems, but could be less robust and is more subject to the presence of outliers.
+Setting `twosteps = True` (default is `True`) will run the optimisation in two steps. The first step employs a trimmed spectrum with reduced dimensions, and is used to identify an initial estimate of the flow velocity (depth effects are neglected during the first step, even when "depth" = 0). During the second step, the search of the optimum is confined within a region between 90% and 110% of the initial estimate. The two-steps approach can reduce the computation time by around 50% for large problems, but could be less robust if the input images are noisy or have a low resolution. In that case, it is recommended to run `twosteps = True` while setting `first_pass_downsample = 1` during the initialisation to avoid an eccessive loss in resolution.
 
 > [!IMPORTANT]
 > Optimization of the velocities occurs with a possibly large amount of spawned parallelized processes.
@@ -303,7 +303,7 @@ iw = Iwave(
 iw.velocimetry(
   alpha=0.85,  # alpha represents the depth-averaged velocity over surface velocity [-]
   depth=0  # depth in [m] has to be known or estimated. If depth = 0, then the depth is estimated.
-  twosteps=False # option to perform the calculation in two steps. If True, the first step is calculated based on
+  twosteps=True # option to perform the calculation in two steps. If True, the first step is calculated based on
                  # a reduced-dimension problem and serves as initialisation of the second step. 
 )
 

--- a/iwave/iwave.py
+++ b/iwave/iwave.py
@@ -44,10 +44,11 @@ class Iwave(object):
         smax: Optional[float] = 4.0,
         dmin: Optional[float] = 0.01,
         dmax: Optional[float] = 3.0,
-        penalty_weight: Optional[float]=1,
         gravity_waves_switch: Optional[bool]=True,
         turbulence_switch: Optional[bool]=True,
         window_chunk_size: Optional[int] = 50,
+        first_pass_downsample: Optional[int]=2,
+        penalty_weight: Optional[float]=1,
     ):
         """Initialize an Iwave instance.
 
@@ -77,11 +78,6 @@ class Iwave(object):
             Minimum depth expected in the scene. Defaults to 0.01 m
         dmax : float, optional
             Maximum depth expected in the scene. Defaults to 3 m
-        penalty_weight : float, optional
-            Parameter to reduce the risk of outliers by penalising solutions with high velocity modulus.
-            Inactive if set to 0. Defaults to 1. 
-            Outliers can be frequent if smax > 2 * flow velocity. Increase penalty_weight only if reducing smax 
-            is not possible, since setting penalty_weight > 0 may introduce a bias.
         gravity_waves_switch: bool, optional
             If True, gravity waves are modelled. If False, gravity waves are NOT modelled. Default True. 
             Setting gravity_waves_swtich = False may improve performance if floating tracers dominate the scene and waves are minimal.
@@ -92,6 +88,13 @@ class Iwave(object):
             dynamics are not representative of the actual flow velocity (e.g., due to air resistance, surface tension, etc.)
         window_chunk_size : int, optional
             Number of windows to process at a time. Defaults to 50.
+        first_pass_downsample : int, optional
+            Downsampling factor to use during the first pass of the two-steps optimisation. Defaults to 2.
+        penalty_weight : float, optional
+            Parameter to reduce the risk of outliers by penalising solutions with high velocity modulus.
+            Inactive if set to 0. Defaults to 1. 
+            Outliers can be frequent if smax > 2 * flow velocity. Increase penalty_weight only if reducing smax 
+            is not possible, since setting penalty_weight > 0 may introduce a bias.
         """
         self.window_chunk_size = window_chunk_size
         self.resolution = resolution
@@ -108,9 +111,10 @@ class Iwave(object):
         self.dmin = dmin
         self.dmax = dmax
         self.fps = fps
-        self.penalty_weight = penalty_weight
         self.gravity_waves_switch = gravity_waves_switch
         self.turbulence_switch = turbulence_switch
+        self.first_pass_downsample = first_pass_downsample
+        self.penalty_weight = penalty_weight
         if imgs is not None:
             self.imgs = imgs
         else:
@@ -417,10 +421,10 @@ class Iwave(object):
         self,
         alpha: float = 0.85,
         depth: float = 1.,  # If depth = 0, then the water depth is estimated.
-        twosteps: bool = False,
+        twosteps: bool = True,
         **opt_kwargs # If True, the calculations are initially performed on a spectrum with reduced dimensions,
                             # and subsequently refined during a second step using the whole spectrum. This will reduce 
-                            # computational time for large problems, but may reduce accuracy.
+                            # computational time for large problems.
     ):
         """
         Estimate and set the velocity components u and v on the instance from the subwindowed spectra.
@@ -439,7 +443,7 @@ class Iwave(object):
             depth of the water column [m], default 1. If set to 0. it will be estimated.
         twosteps : bool, optional
             if set, perform the optimisation twice, with a reduced spectrum in the first step without optimizing depth
-            and full spectrum in the second step with optimizing depth. Default False.
+            and full spectrum in the second step with optimizing depth. Default True.
         See also
         --------
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html
@@ -453,11 +457,11 @@ class Iwave(object):
         if not opt_kwargs:
             opt_kwargs = OPTIM_KWARGS_SADE
         # set search bounds to -/+ maximum velocity for both directions
+        if (twosteps == False) & (self.penalty_weight != 0):
+                # self.penalty_weight = 0
+                print(f"Velocity and especially depth estimations with the 1 step approach are biased when penalty_weight is not zero. It is recommended to use the two steps approach and/or set first_pass_downsample=1, or alternatively to set penalty_weight = 0 and decreasing smax to reduce the number of outliers.")
         if depth == 0:  # If depth = 0, then the water depth is estimated.
             bounds = [(-self.smax, self.smax), (-self.smax, self.smax), (self.dmin, self.dmax)]
-            if twosteps == False:
-                self.penalty_weight = 0
-                print(f"Depth estimation with the 1 step approach is inaccurate when penalty_weight is not zero. Now setting penalty_weight = 0. Consider reducing smax if results are incorrect, or use the two-steps approach.")
         else:
             bounds = [(-self.smax, self.smax), (-self.smax, self.smax), (depth, depth)]
         # Create a list of bounds for each window. This is to enable narrowing the bounds locally during multiple passages.
@@ -478,7 +482,7 @@ class Iwave(object):
                 self.penalty_weight,  
                 self.gravity_waves_switch, 
                 self.turbulence_switch, 
-                downsample=2, # for the first step, reduce the data size by 2
+                downsample=self.first_pass_downsample, # for the first step, reduce the data size by 2
                 gauss_width=1,  # TODO: figure out defaults
                 desc="Optimizing windows 1st pass",
                 **opt_kwargs


### PR DESCRIPTION
Set `twosteps = True` as default to avoid the bias when `penalty_weight` is different from zero.
When iwave is run using `twosteps = False` and `penalty_weight != 0`, an alert advises about the potential bias, and recommends an alternative safe (but potentially slower) approach.